### PR TITLE
Fix the icon injection

### DIFF
--- a/src/main/java/net/wiredtomato/waygl/mixin/WindowMixin.java
+++ b/src/main/java/net/wiredtomato/waygl/mixin/WindowMixin.java
@@ -19,7 +19,7 @@ import static org.lwjgl.glfw.GLFW.*;
 public abstract class WindowMixin {
 
 	@Inject(method = "<init>", at = @At(value = "INVOKE", target = "Lorg/lwjgl/glfw/GLFW;glfwCreateWindow(IILjava/lang/CharSequence;JJ)J"))
-	public void waygl$addWindowHints(WindowEventHandler windowEventHandler, MonitorTracker monitorTracker, WindowSettings windowSettings, String string, String string2, CallbackInfo ci) {
+	private void waygl$addWindowHints(WindowEventHandler windowEventHandler, MonitorTracker monitorTracker, WindowSettings windowSettings, String string, String string2, CallbackInfo ci) {
 		if (WayGL.useWayland()) {
 			glfwWindowHint(GLFW_FOCUS_ON_SHOW, GLFW_FALSE);
 			IconInjector.INSTANCE.inject();

--- a/src/main/java/net/wiredtomato/waygl/mixin/WindowMixin.java
+++ b/src/main/java/net/wiredtomato/waygl/mixin/WindowMixin.java
@@ -1,16 +1,14 @@
 package net.wiredtomato.waygl.mixin;
 
-import net.minecraft.SharedConstants;
-import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.WindowEventHandler;
 import net.minecraft.client.WindowSettings;
-import net.minecraft.client.util.*;
+import net.minecraft.client.util.Icons;
+import net.minecraft.client.util.MonitorTracker;
+import net.minecraft.client.util.Window;
 import net.minecraft.resource.ResourcePack;
 import net.wiredtomato.waygl.IconInjector;
 import net.wiredtomato.waygl.WayGL;
-import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -19,29 +17,21 @@ import static org.lwjgl.glfw.GLFW.*;
 
 @Mixin(Window.class)
 public abstract class WindowMixin {
-    @Shadow @Final private long handle;
 
-    @Inject(method = "<init>", at = @At(value = "INVOKE", target = "Lorg/lwjgl/glfw/GLFW;glfwCreateWindow(IILjava/lang/CharSequence;JJ)J"))
-    public void waygl$addWindowHints(WindowEventHandler windowEventHandler, MonitorTracker monitorTracker, WindowSettings windowSettings, String string, String string2, CallbackInfo ci) {
-        if (WayGL.useWayland()) {
-            glfwWindowHint(GLFW_FOCUS_ON_SHOW, GLFW_FALSE);
-            IconInjector.INSTANCE.inject();
-            glfwWindowHintString(GLFW_WAYLAND_APP_ID, IconInjector.INSTANCE.getAPP_ID());
-        }
-    }
+	@Inject(method = "<init>", at = @At(value = "INVOKE", target = "Lorg/lwjgl/glfw/GLFW;glfwCreateWindow(IILjava/lang/CharSequence;JJ)J"))
+	public void waygl$addWindowHints(WindowEventHandler windowEventHandler, MonitorTracker monitorTracker, WindowSettings windowSettings, String string, String string2, CallbackInfo ci) {
+		if (WayGL.useWayland()) {
+			glfwWindowHint(GLFW_FOCUS_ON_SHOW, GLFW_FALSE);
+			IconInjector.INSTANCE.inject();
+			glfwWindowHintString(GLFW_WAYLAND_APP_ID, IconInjector.APP_ID);
+		}
+	}
 
-    @Inject(method = "<init>", at = @At(value = "INVOKE", target = "Lorg/lwjgl/glfw/GLFW;glfwSetCursorEnterCallback(JLorg/lwjgl/glfw/GLFWCursorEnterCallbackI;)Lorg/lwjgl/glfw/GLFWCursorEnterCallback;"))
-    public void waygl$setIcon(WindowEventHandler windowEventHandler, MonitorTracker monitorTracker, WindowSettings windowSettings, String string, String string2, CallbackInfo ci) {
-        if (WayGL.useWayland()) {
-            glfwShowWindow(handle);
-            IconInjector.INSTANCE.setIcon(MinecraftClient.getInstance().getDefaultResourcePack(), SharedConstants.getGameVersion().isStable() ? Icons.RELEASE : Icons.SNAPSHOT);
-        }
-    }
-
-    @Inject(method = "setIcon", at = @At("HEAD"), cancellable = true)
-    public void waygl$cancelIcon(ResourcePack resourcePack, Icons icons, CallbackInfo ci) {
-        if (WayGL.useWayland()) {
-            ci.cancel();
-        }
-    }
+	@Inject(method = "setIcon", at = @At("HEAD"), cancellable = true)
+	private void waygl$setIcon(ResourcePack resourcePack, Icons icons, CallbackInfo ci) {
+		if (WayGL.useWayland()) {
+			IconInjector.INSTANCE.setIcon(resourcePack, icons);
+			ci.cancel();
+		}
+	}
 }

--- a/src/main/kotlin/net/wiredtomato/waygl/IconInjector.kt
+++ b/src/main/kotlin/net/wiredtomato/waygl/IconInjector.kt
@@ -4,22 +4,19 @@ import net.fabricmc.loader.api.FabricLoader
 import net.minecraft.client.util.Icons
 import net.minecraft.resource.ResourcePack
 import java.awt.image.BufferedImage
-import java.io.ByteArrayOutputStream
-import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 import javax.imageio.ImageIO
-import kotlin.math.sqrt
 
 
 object IconInjector {
-    val APP_ID = "com.mojang.minecraft"
-    val ICON_NAME = "minecraft.png"
-    val FILE_NAME = "$APP_ID.desktop"
-    val LOCATION = "/assets/${WayGL.MODID}/$FILE_NAME"
-    val injects = mutableListOf<Path>()
+    const val APP_ID = "com.mojang.minecraft"
+    private const val ICON_NAME = "minecraft.png"
+    private const val FILE_NAME = "$APP_ID.desktop"
+    private const val LOCATION = "/assets/${WayGL.MODID}/$FILE_NAME"
+    private val injects = mutableListOf<Path>()
 
     fun inject() {
         Runtime.getRuntime().addShutdownHook(Thread(IconInjector::uninject))
@@ -52,11 +49,14 @@ object IconInjector {
         val result = {
             val suppliers = icons.getIcons(resourcePack)
 
-            val rawIcons = suppliers.map {
-                ByteBuffer.wrap(it.get().readAllBytes())
-            }.toTypedArray()
-
-            setIcon(rawIcons)
+            suppliers.forEach {
+                val image: BufferedImage = ImageIO.read(it.get())
+                val target: Path = getIconFileLoc(
+                    image.width,
+                    image.height
+                )
+                injectFile(target, it.get().readAllBytes())
+            }
         }.runCatching {
             this()
         }
@@ -64,37 +64,6 @@ object IconInjector {
         if (result.isFailure) {
             throw result.exceptionOrNull()!!
         }
-    }
-
-    private fun setIcon(icons: Array<ByteBuffer>): Int {
-        icons.forEach { icon ->
-            val result = {
-                val pixels = mutableListOf<Int>()
-                for (i in 0 until icon.remaining() / 4) {
-                    pixels.add(Integer.rotateRight(icon.getInt(), 8))
-                }
-                val size = sqrt(pixels.size.toDouble()).toInt()
-                val image = BufferedImage(size, size, BufferedImage.TYPE_INT_ARGB)
-                image.setRGB(0, 0, size, size, pixels.toIntArray(), 0, size)
-                val target: Path = getIconFileLoc(image.width, image.height)
-                val outputStream = ByteArrayOutputStream()
-                ImageIO.write(image, "png", outputStream)
-
-                injectFile(target, outputStream.toByteArray())
-            }.runCatching {
-                this()
-            }
-
-            if (result.isFailure) {
-                return 1
-            }
-        }
-
-
-
-        updateIconSys()
-
-        return 0
     }
 
     private fun injectFile(target: Path, data: ByteArray) {

--- a/src/main/kotlin/net/wiredtomato/waygl/WayGL.kt
+++ b/src/main/kotlin/net/wiredtomato/waygl/WayGL.kt
@@ -2,6 +2,7 @@ package net.wiredtomato.waygl
 
 import net.minecraft.util.Identifier
 import org.lwjgl.glfw.GLFW
+import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 @Suppress("unused")
@@ -9,42 +10,30 @@ object WayGL {
     const val MODID = "waygl"
 
     @JvmField
-    val LOGGER = LoggerFactory.getLogger(WayGL::class.java)
+    val LOGGER: Logger = LoggerFactory.getLogger(WayGL::class.java)
 
     @JvmStatic
-    val osString: String by lazy { System.getProperty("os.name") }
-    @JvmStatic
-    val osLinuxBased: Boolean by lazy { osString == "Linux" }
+    val platform : Int by lazy { GLFW.glfwGetPlatform() }
 
     @JvmStatic
-    val displayServerType: String  by lazy {  System.getenv("XDG_SESSION_TYPE") }
-    @JvmStatic
-    val isWayland: Boolean by lazy { displayServerType == "wayland" }
+    val isWayland : Boolean by lazy { platform == GLFW.GLFW_PLATFORM_WAYLAND }
 
     fun clientInit() {
-        if (!osLinuxBased) {
-            LOGGER.info("Current OS is $osString, it is not linux based, no action will be taken.")
-            return
-        }
 
-        LOGGER.info(
-            "Current display server is $displayServerType, ${
-                if (isWayland) "forcing glfw to use wayland!" 
-                else "no action will be taken."
-            }"
-        )
     }
 
     @JvmStatic
     fun tryUseWayland() {
-        if (useWayland()) {
-            GLFW.glfwInitHint(GLFW.GLFW_PLATFORM, GLFW.GLFW_PLATFORM_WAYLAND)
-        }
+        // The init hint only allows the wayland backend to be selected.
+        // GLFW chooses the platform by itself.
+        GLFW.glfwInitHint(GLFW.GLFW_PLATFORM, GLFW.GLFW_PLATFORM_WAYLAND)
     }
 
     @JvmStatic
     fun useWayland(): Boolean {
-        return osLinuxBased && isWayland
+        // If GLFW chose wayland as the platform we can safely assume that we run on wayland.
+        // Note that this function may only be called *after* glfwInit has been called.
+        return isWayland
     }
 
     fun id(path: String) = Identifier(MODID, path)


### PR DESCRIPTION
You probably didn't notice that, but the format the icon is set is different between lwjgl2 (RGBA) and lwjgl3 (ARGB). Since awt's BufferedImage only accepts ARGB values, the pixel colors needed to be modified (with `Integer.rotateRight`). You may decide yourself whether you also want to include the second commit.