### PR TITLE
Fix virtual cursor position on scaled monitors

### DIFF
--- a/src/main/kotlin/net/wiredtomato/waygl/VirtualCursor.kt
+++ b/src/main/kotlin/net/wiredtomato/waygl/VirtualCursor.kt
@@ -108,13 +108,24 @@ object VirtualCursor {
             RenderSystem.setShaderColor(1f, 1f, 1f, 1f)
             RenderSystem.setShaderTexture(0, image)
 
-            val scale = MinecraftClient.getInstance().window.scaleFactor
+            val window = MinecraftClient.getInstance().window
+            val scale = window.scaleFactor
+
+            val monitor = window.monitor
+            var monitorScale = 1f
+            if (monitor != null) {
+                val monitorScaleX = FloatArray(1)
+                val monitorScaleY = FloatArray(1)
+                GLFW.glfwGetMonitorContentScale(monitor.handle, monitorScaleX, monitorScaleY)
+                monitorScale = monitorScaleX[0]
+            }
+
             val x = getX().toFloat()
             val y = getY().toFloat()
 
             context.matrices.push()
             context.matrices.translate(0f, 0f, 1000f)
-            context.matrices.scale((1f / scale).toFloat(), (1f / scale).toFloat(), 0f)
+            context.matrices.scale((monitorScale / scale).toFloat(), (monitorScale / scale).toFloat(), 0f)
             context.drawTexture(
                 image,
                 (x - (getCurrent().xhot / scale)).toInt(),


### PR DESCRIPTION
As mentioned in #11, the virtual cursor can appear in the wrong location when you're monitor's scale factor is set to something other than 100%. This replaces the assumed monitor scale of 1f and replaces it with the value reported by GLFW. This fix worked for me at every scale factor I tested it on, which was 50%, 100%, 150%, 200%, 250%, and 300%. However, it doesn't seem to work if you move the window from one monitor to another monitor with a different scale factor