### PR TITLE
Some fixes and zh-hans translations

### DIFF
--- a/mod/common/src/main/kotlin/net/wiredtomato/waygl/WayGL.kt
+++ b/mod/common/src/main/kotlin/net/wiredtomato/waygl/WayGL.kt
@@ -22,7 +22,10 @@ object WayGL {
     val LOGGER: Logger = LoggerFactory.getLogger("WayGL")
 
     @JvmStatic
-    val useWayland: Boolean by lazy { GLFW.glfwPlatformSupported(GLFW.GLFW_PLATFORM_WAYLAND) }
+    val useWayland: Boolean by lazy {
+        (GLFW.glfwPlatformSupported(GLFW.GLFW_PLATFORM_WAYLAND)
+                && (System.getenv("XDG_SESSION_TYPE")?.lowercase() ?: "").startsWith("wayland"))
+    }
 
     @JvmStatic
     val platform: Int by lazy { GLFW.glfwGetPlatform() }

--- a/mod/common/src/main/resources/assets/waygl/lang/zh_cn.json
+++ b/mod/common/src/main/resources/assets/waygl/lang/zh_cn.json
@@ -1,0 +1,10 @@
+{
+  "yacl3.config.waygl:waygl.title":"WayGL 配置",
+  "yacl3.config.waygl:waygl.useNativeGlfw": "使用本地GLFW",
+  "yacl3.config.waygl:waygl.nativeGlfwPath": "本地GLFW路径",
+  "yacl3.config.waygl:waygl.category.glfw": "GLFW",
+  "waygl.warning.early_window_active": "预加载窗口已启用",
+  "waygl.warning.early_window_active.desc": "因窗口在Mixin注入之前就已初始化\n导致WayGL无法为GLFW启用Wayland支持 \n在FML配置中禁用 \"earlyWindowControl\" \n即可解决此问题。",
+  "waygl.warning.early_window_active.continue": "暂不禁用预加载窗口并继续",
+  "waygl.warning.early_window_active.disable": "禁用预加载窗口并关闭游戏"
+}

--- a/mod/fabric/build.gradle.kts
+++ b/mod/fabric/build.gradle.kts
@@ -77,7 +77,8 @@ modrinth {
     versionType = "release"
     gameVersions = minecraft_versions
     loaders.set(listOf("fabric"))
-    uploadFile = tasks.jar.get()
+    // uploadFile = tasks.jar.get()
+    uploadFile = tasks.remapJar.get()
     dependencies {
         required.project("fabric-language-kotlin")
         required.project("fabric-api")


### PR DESCRIPTION
- 63c3a824aa75a9084ff8c6ad097f50a2d55d6d1e this should fix #30  (jar file for fabric on modrinth is dev-jar which mojang's methods aren't obfuscated, this commit should solve this) 

- a29e24b55581be895393fc02d4cf926f840bd77d Fixes crash issue when glfw compiled with wayland support but system still uses x11

- c3067210826e2d5bc9e0baed812122109bb5a8fb Simplified Chinese translations